### PR TITLE
When raising exceptions, always passing an exception class.

### DIFF
--- a/lib/instagram_reporter/instagram_api_caller.rb
+++ b/lib/instagram_reporter/instagram_api_caller.rb
@@ -21,7 +21,7 @@ class InstagramApiCaller < InstagramInteractionsBase
       end
       return parse_json(response.body)
     rescue Exception => ex
-      raise "Failed to obtain instagram accounts by api token wit exception #{ex.inspect} for response #{response.inspect}"
+      raise ex, "Failed to obtain instagram accounts by api token wit exception #{ex.inspect} for response #{response.inspect}"
     end
   end
 
@@ -33,7 +33,7 @@ class InstagramApiCaller < InstagramInteractionsBase
       end
       return parse_json(response.body)
     rescue Exception => ex
-      raise "Failed to obtain instagram accounts by access token with exception #{ex.inspect} for response #{response.inspect}"
+      raise ex, "Failed to obtain instagram accounts by access token with exception #{ex.inspect} for response #{response.inspect}"
     end
   end
 

--- a/lib/instagram_reporter/instagram_interactions_base.rb
+++ b/lib/instagram_reporter/instagram_interactions_base.rb
@@ -13,6 +13,6 @@ class InstagramInteractionsBase
 
   private
   def check_env_variables 
-      raise "INSTAGRAM_API_TOKEN environment variable not set" unless API_TOKEN
+      raise ArgumentError, "INSTAGRAM_API_TOKEN environment variable not set" unless API_TOKEN
   end
 end

--- a/lib/instagram_reporter/version.rb
+++ b/lib/instagram_reporter/version.rb
@@ -1,3 +1,3 @@
 module InstagramReporter
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/instagram_api_caller_spec.rb
+++ b/spec/instagram_api_caller_spec.rb
@@ -18,7 +18,7 @@ describe InstagramApiCaller do
 
     it "should raise error if environmental variable INSTAGRAM_API_TOKEN is not set on class initialization" do
       InstagramInteractionsBase::API_TOKEN = nil
-      expect { InstagramApiCaller.new }.to raise_error(RuntimeError, 'INSTAGRAM_API_TOKEN environment variable not set')
+      expect { InstagramApiCaller.new }.to raise_error(ArgumentError, 'INSTAGRAM_API_TOKEN environment variable not set')
     end
 
     after(:all) do

--- a/spec/instagram_website_caller_spec.rb
+++ b/spec/instagram_website_caller_spec.rb
@@ -14,7 +14,7 @@ describe InstagramWebsiteCaller do
 
     it "should raise error if environmental variable INSTAGRAM_API_TOKEN is not set on class initialization" do
       InstagramInteractionsBase::API_TOKEN = nil
-      expect{InstagramWebsiteCaller.new}.to raise_error(RuntimeError, 'INSTAGRAM_API_TOKEN environment variable not set')
+      expect{InstagramWebsiteCaller.new}.to raise_error(ArgumentError, 'INSTAGRAM_API_TOKEN environment variable not set')
     end
     
     it "should assign envirnomental variable to appropriate class variable if env variable is not empty" do


### PR DESCRIPTION
To be able to distinct exception class out of the gem we need to pass exception object when raising exception.  
